### PR TITLE
Only register the render buffers once, when they have all been constr…

### DIFF
--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -319,6 +319,15 @@ extern "C" OSVR_ReturnCode UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API ConstructR
 			return OSVR_RETURN_FAILURE;
 		}
 	}
+
+  // Register our constructed buffers so that we can use them for
+  // presentation.
+  DebugLog("RegisterRenderBuffers() being called");
+  if (!render->RegisterRenderBuffers(renderBuffers)) {
+    DebugLog("RegisterRenderBuffers() returned false, cannot continue");
+    return OSVR_RETURN_FAILURE;
+  }
+
 	return OSVR_RETURN_SUCCESS;
 }
 
@@ -466,14 +475,7 @@ int ConstructBuffersD3D11(int eye)
 	rb.D3D11 = rbD3D;
 	renderBuffers.push_back(rb);
 
-	// Register our constructed buffers so that we can use them for
-	// presentation.
-	if (!render->RegisterRenderBuffers(renderBuffers)) {
-		DebugLog("RegisterRenderBuffers() returned false, cannot continue");
-		return OSVR_RETURN_FAILURE;
-	}
-	
-	return OSVR_RETURN_SUCCESS;
+  return OSVR_RETURN_SUCCESS;
 }
 
 // Renders the view from our Unity cameras by copying data at Unity.RenderTexture.GetNativeTexturePtr() to RenderManager colorBuffers


### PR DESCRIPTION
…ucted.

This avoids duplicate registration of the 0th buffer.  A cleaner approach that might also avoid trouble in the future.