### PR TITLE
Fixes a regression causing the display to freeze with image of previo…

### DIFF
--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -717,6 +717,19 @@ int UNITY_INTERFACE_API SetColorBufferFromUnity(void *texturePtr, int eye) {
 
     return OSVR_RETURN_SUCCESS;
 }
+#if SUPPORT_D3D11
+// Renders the view from our Unity cameras by copying data at
+// Unity.RenderTexture.GetNativeTexturePtr() to RenderManager colorBuffers
+void RenderViewD3D11(const osvr::renderkit::RenderInfo &ri,
+	ID3D11RenderTargetView *renderTargetView, int eyeIndex) {
+	auto context = ri.library.D3D11->context;
+	// Set up to render to the textures for this eye
+	context->OMSetRenderTargets(1, &renderTargetView, NULL);
+
+	// copy the updated RenderTexture from Unity to RenderManager colorBuffer
+	s_renderBuffers[eyeIndex].D3D11->colorBuffer = GetEyeTextureD3D11(eyeIndex);
+}
+#endif // SUPPORT_D3D11
 
 #if SUPPORT_OPENGL
 // Render the world from the specified point of view.
@@ -801,6 +814,11 @@ inline void DoRender() {
     switch (s_deviceType.getDeviceTypeEnum()) {
 #if SUPPORT_D3D11
     case OSVRSupportedRenderers::D3D11: {
+		// Render into each buffer using the specified information.
+		for (int i = 0; i < n; ++i) {
+			RenderViewD3D11(s_renderInfo[i],
+				s_renderBuffers[i].D3D11->colorBufferView, i);
+		}
 
         // Send the rendered results to the screen
         // Flip Y because Unity RenderTextures are upside-down on D3D11


### PR DESCRIPTION
…us scene.
 A commit in the x86 patch PR caused a regression when switching scenes in some cases. This fixes that issue.