### PR TITLE
New data types

### DIFF
--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -711,12 +711,11 @@ OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(std::uint8_t eye) {
 	osvrPose3SetIdentity(&pose);
 	if (s_renderInfo.size() > 0 && eye <= s_renderInfo.size() - 1)
 	{
-		std::string errorLog = "[OSVR Rendering Plugin] working, eye = " + eye;
 		pose = s_renderInfo[eye].pose;
 	}
 	else
 	{
-		std::string errorLog = "[OSVR Rendering Plugin] Index out of range in GetEyePose, eye = " + eye;
+		std::string errorLog = "[OSVR Rendering Plugin] working, eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
 	}
 	return pose;

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -687,6 +687,8 @@ GetViewport(std::uint8_t eye) {
 	{
 		std::string errorLog = "[OSVR Rendering Plugin] error in GetViewport, eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
+		errorLog = "[OSVR Rendering Plugin] renderInfo array size is = " + std::to_string(int(s_renderInfo.size()));
+		DebugLog(errorLog.c_str());
 	}
 	return viewportDescription;
 }
@@ -702,6 +704,8 @@ GetProjectionMatrix(std::uint8_t eye) {
 	{
 		std::string errorLog = "[OSVR Rendering Plugin] error in GetProjectionMatrix, eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
+		errorLog = "[OSVR Rendering Plugin] renderInfo array size is = " + std::to_string(int(s_renderInfo.size()));
+		DebugLog(errorLog.c_str());
 	}
 	return pm;
 }
@@ -716,6 +720,8 @@ OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(std::uint8_t eye) {
 	else
 	{
 		std::string errorLog = "[OSVR Rendering Plugin] error in GetEyePose, eye = " + std::to_string(int(eye));
+		DebugLog(errorLog.c_str());
+		errorLog = "[OSVR Rendering Plugin] renderInfo array size is = " + std::to_string(int(s_renderInfo.size()));
 		DebugLog(errorLog.c_str());
 	}
 	return pose;

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -92,6 +92,9 @@ static double s_nearClipDistance = 0.1;
 static double s_farClipDistance = 1000.0;
 /// @todo is this redundant? (given renderParams)
 static double s_ipd = 0.063;
+//cached viewport values
+static std::uint32_t viewportWidth = 0;
+static std::uint32_t viewportHeight = 0;
 
 #if defined(ENABLE_LOGGING) && defined(ENABLE_LOGFILE)
 static std::ofstream s_debugLogFile;
@@ -682,25 +685,27 @@ GetViewport(std::uint8_t eye) {
 	if (s_renderInfo.size() > 0 && eye <= s_renderInfo.size() - 1)
 	{
 		viewportDescription = s_renderInfo[eye].viewport;
-		/*std::string d0 = "[OSVR Rendering Plugin] viewportDescription, eye = " + std::to_string(int(eye));
-		std::string d1 = "left = " + std::to_string(int(s_renderInfo[eye].viewport.left));
-		std::string d2 = "lower = " + std::to_string(int(s_renderInfo[eye].viewport.lower));
-		std::string d3 = "width = " + std::to_string(int(s_renderInfo[eye].viewport.width));
-		std::string d4 = "height = " + std::to_string(int(s_renderInfo[eye].viewport.height));
-		std::string d5 = d0 + "\n" + d1 + "\n" + d2 + "\n" + d3 + "\n" + d4 + "\n";
-		DebugLog(d5.c_str());*/
 
+		//cache the viewport width and height
+		//patches issue where sometimes empty viewport is returned
+		//@todo fix the real cause of why this method bugs out occasionally on some machines, more often on others
+		if (viewportWidth == 0 && s_renderInfo[eye].viewport.width != 0)
+		{
+			viewportWidth = s_renderInfo[eye].viewport.width;
+		}
+		if (viewportHeight == 0 && s_renderInfo[eye].viewport.height != 0)
+		{
+			viewportHeight = s_renderInfo[eye].viewport.height;
+		}
 	}
 	else
 	{
-		std::string errorLog = "[OSVR Rendering Plugin] error in GetViewport, eye = " + std::to_string(int(eye));
-		DebugLog(errorLog.c_str());
-		errorLog = "[OSVR Rendering Plugin] renderInfo array size is = " + std::to_string(int(s_renderInfo.size()));
+		std::string errorLog = "[OSVR Rendering Plugin] Error in GetViewport, returning cached values. Eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
 		viewportDescription.left = 0;
 		viewportDescription.lower = 0;
-		viewportDescription.width = 1080;
-		viewportDescription.height = 1200;
+		viewportDescription.width = viewportWidth;
+		viewportDescription.height = viewportHeight;
 	}
 	return viewportDescription;
 }

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -685,7 +685,7 @@ GetViewport(std::uint8_t eye) {
 	}
 	else
 	{
-		std::string errorLog = "[OSVR Rendering Plugin] working, eye = " + std::to_string(int(eye));
+		std::string errorLog = "[OSVR Rendering Plugin] error in GetViewport, eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
 	}
 	return viewportDescription;
@@ -700,7 +700,7 @@ GetProjectionMatrix(std::uint8_t eye) {
 	}
 	else
 	{
-		std::string errorLog = "[OSVR Rendering Plugin] working, eye = " + std::to_string(int(eye));
+		std::string errorLog = "[OSVR Rendering Plugin] error in GetProjectionMatrix, eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
 	}
 	return pm;
@@ -715,7 +715,7 @@ OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(std::uint8_t eye) {
 	}
 	else
 	{
-		std::string errorLog = "[OSVR Rendering Plugin] working, eye = " + std::to_string(int(eye));
+		std::string errorLog = "[OSVR Rendering Plugin] error in GetEyePose, eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
 	}
 	return pose;

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -685,7 +685,7 @@ GetViewport(std::uint8_t eye) {
 	}
 	else
 	{
-		std::string errorLog = "[OSVR Rendering Plugin] Index out of range in GetViewport, eye = " + eye;
+		std::string errorLog = "[OSVR Rendering Plugin] working, eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
 	}
 	return viewportDescription;
@@ -700,7 +700,7 @@ GetProjectionMatrix(std::uint8_t eye) {
 	}
 	else
 	{
-		std::string errorLog = "[OSVR Rendering Plugin] Index out of range in GetProjectionMatrix, eye = " + eye;
+		std::string errorLog = "[OSVR Rendering Plugin] working, eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
 	}
 	return pm;

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -677,17 +677,49 @@ void UNITY_INTERFACE_API SetIPD(double ipdMeters) {
 }
 
 osvr::renderkit::OSVR_ViewportDescription UNITY_INTERFACE_API
-GetViewport(int eye) {
-    return s_renderInfo[eye].viewport;
+GetViewport(std::uint8_t eye) {
+	osvr::renderkit::OSVR_ViewportDescription viewportDescription;
+	if (s_renderInfo.size() > 0 && eye <= s_renderInfo.size() - 1)
+	{
+		viewportDescription = s_renderInfo[eye].viewport;
+	}
+	else
+	{
+		std::string errorLog = "[OSVR Rendering Plugin] Index out of range in GetViewport, eye = " + eye;
+		DebugLog(errorLog.c_str());
+	}
+	return viewportDescription;
 }
 
 osvr::renderkit::OSVR_ProjectionMatrix UNITY_INTERFACE_API
-GetProjectionMatrix(int eye) {
-    return s_renderInfo[eye].projection;
+GetProjectionMatrix(std::uint8_t eye) {
+	osvr::renderkit::OSVR_ProjectionMatrix pm;
+	if (s_renderInfo.size() > 0 && eye <= s_renderInfo.size() - 1)
+	{
+		pm = s_renderInfo[eye].projection;
+	}
+	else
+	{
+		std::string errorLog = "[OSVR Rendering Plugin] Index out of range in GetProjectionMatrix, eye = " + eye;
+		DebugLog(errorLog.c_str());
+	}
+	return pm;
 }
 
-OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(int eye) {
-    return s_renderInfo[eye].pose;
+OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(std::uint8_t eye) {
+	OSVR_Pose3 pose;
+	osvrPose3SetIdentity(&pose);
+	if (s_renderInfo.size() > 0 && eye <= s_renderInfo.size() - 1)
+	{
+		std::string errorLog = "[OSVR Rendering Plugin] working, eye = " + eye;
+		pose = s_renderInfo[eye].pose;
+	}
+	else
+	{
+		std::string errorLog = "[OSVR Rendering Plugin] Index out of range in GetEyePose, eye = " + eye;
+		DebugLog(errorLog.c_str());
+	}
+	return pose;
 }
 
 // --------------------------------------------------------------------------
@@ -703,7 +735,7 @@ OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(int eye) {
 // to set up needed texture pointers only at initialization time.
 // For more reference, see:
 // http://docs.unity3d.com/ScriptReference/Texture.GetNativeTexturePtr.html
-int UNITY_INTERFACE_API SetColorBufferFromUnity(void *texturePtr, int eye) {
+int UNITY_INTERFACE_API SetColorBufferFromUnity(void *texturePtr, std::uint8_t eye) {
     if (!s_deviceType) {
         return OSVR_RETURN_FAILURE;
     }

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -21,8 +21,8 @@ Sensics, Inc.
 // limitations under the License.
 
 /// Both of these need to be enabled to force-enable logging to files.
-#define ENABLE_LOGGING 1
-#define ENABLE_LOGFILE 1
+#undef ENABLE_LOGGING
+#undef ENABLE_LOGFILE
 
 // Internal includes
 #include "OsvrRenderingPlugin.h"
@@ -700,6 +700,7 @@ GetViewport(std::uint8_t eye) {
 	}
 	else
 	{
+		//we shouldn't be here unless we hit a bug, in which case, we avoid error by returning cached viewport values
 		std::string errorLog = "[OSVR Rendering Plugin] Error in GetViewport, returning cached values. Eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
 		viewportDescription.left = 0;
@@ -719,9 +720,7 @@ GetProjectionMatrix(std::uint8_t eye) {
 	}
 	else
 	{
-		std::string errorLog = "[OSVR Rendering Plugin] error in GetProjectionMatrix, eye = " + std::to_string(int(eye));
-		DebugLog(errorLog.c_str());
-		errorLog = "[OSVR Rendering Plugin] renderInfo array size is = " + std::to_string(int(s_renderInfo.size()));
+		std::string errorLog = "[OSVR Rendering Plugin] Error in GetProjectionMatrix, returning default values. Eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
 	}
 	return pm;
@@ -736,9 +735,7 @@ OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(std::uint8_t eye) {
 	}
 	else
 	{
-		std::string errorLog = "[OSVR Rendering Plugin] error in GetEyePose, eye = " + std::to_string(int(eye));
-		DebugLog(errorLog.c_str());
-		errorLog = "[OSVR Rendering Plugin] renderInfo array size is = " + std::to_string(int(s_renderInfo.size()));
+		std::string errorLog = "[OSVR Rendering Plugin] Error in GetEyePose, returning default values. Eye = " + std::to_string(int(eye));
 		DebugLog(errorLog.c_str());
 	}
 	return pose;

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -21,8 +21,8 @@ Sensics, Inc.
 // limitations under the License.
 
 /// Both of these need to be enabled to force-enable logging to files.
-#undef ENABLE_LOGGING
-#undef ENABLE_LOGFILE
+#define ENABLE_LOGGING 1
+#define ENABLE_LOGFILE 1
 
 // Internal includes
 #include "OsvrRenderingPlugin.h"
@@ -634,7 +634,7 @@ inline void CleanupBufferD3D11(osvr::renderkit::RenderBuffer &rb) {
 
 OSVR_ReturnCode UNITY_INTERFACE_API ConstructRenderBuffers() {
     if (!s_deviceType) {
-        DebugLog("Device type not supported.");
+        DebugLog("[OSVR Rendering Plugin] Device type not supported.");
         return OSVR_RETURN_FAILURE;
     }
     UpdateRenderInfo();

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -682,6 +682,14 @@ GetViewport(std::uint8_t eye) {
 	if (s_renderInfo.size() > 0 && eye <= s_renderInfo.size() - 1)
 	{
 		viewportDescription = s_renderInfo[eye].viewport;
+		/*std::string d0 = "[OSVR Rendering Plugin] viewportDescription, eye = " + std::to_string(int(eye));
+		std::string d1 = "left = " + std::to_string(int(s_renderInfo[eye].viewport.left));
+		std::string d2 = "lower = " + std::to_string(int(s_renderInfo[eye].viewport.lower));
+		std::string d3 = "width = " + std::to_string(int(s_renderInfo[eye].viewport.width));
+		std::string d4 = "height = " + std::to_string(int(s_renderInfo[eye].viewport.height));
+		std::string d5 = d0 + "\n" + d1 + "\n" + d2 + "\n" + d3 + "\n" + d4 + "\n";
+		DebugLog(d5.c_str());*/
+
 	}
 	else
 	{
@@ -689,6 +697,10 @@ GetViewport(std::uint8_t eye) {
 		DebugLog(errorLog.c_str());
 		errorLog = "[OSVR Rendering Plugin] renderInfo array size is = " + std::to_string(int(s_renderInfo.size()));
 		DebugLog(errorLog.c_str());
+		viewportDescription.left = 0;
+		viewportDescription.lower = 0;
+		viewportDescription.width = 1080;
+		viewportDescription.height = 1200;
 	}
 	return viewportDescription;
 }

--- a/OsvrRenderingPlugin.h
+++ b/OsvrRenderingPlugin.h
@@ -28,6 +28,7 @@ Sensics, Inc.
 #include <osvr/RenderKit/RenderKitGraphicsTransforms.h>
 #include <osvr/Util/ClientOpaqueTypesC.h>
 #include <osvr/Util/ReturnCodesC.h>
+#include <cstdint>
 
 typedef void(UNITY_INTERFACE_API *DebugFnPtr)(const char *);
 
@@ -45,18 +46,18 @@ ConstructRenderBuffers();
 UNITY_INTERFACE_EXPORT OSVR_ReturnCode UNITY_INTERFACE_API
 CreateRenderManagerFromUnity(OSVR_ClientContext context);
 
-UNITY_INTERFACE_EXPORT OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(int eye);
+UNITY_INTERFACE_EXPORT OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(std::uint8_t eye);
 
 UNITY_INTERFACE_EXPORT osvr::renderkit::OSVR_ProjectionMatrix
     UNITY_INTERFACE_API
-    GetProjectionMatrix(int eye);
+	GetProjectionMatrix(std::uint8_t eye);
 
 UNITY_INTERFACE_EXPORT UnityRenderingEvent UNITY_INTERFACE_API
 GetRenderEventFunc();
 
 UNITY_INTERFACE_EXPORT osvr::renderkit::OSVR_ViewportDescription
     UNITY_INTERFACE_API
-    GetViewport(int eye);
+	GetViewport(std::uint8_t eye);
 
 UNITY_INTERFACE_EXPORT void UNITY_INTERFACE_API LinkDebug(DebugFnPtr d);
 
@@ -64,7 +65,7 @@ UNITY_INTERFACE_EXPORT void UNITY_INTERFACE_API OnRenderEvent(int eventID);
 
 /// @todo should return OSVR_ReturnCode
 UNITY_INTERFACE_EXPORT int UNITY_INTERFACE_API
-SetColorBufferFromUnity(void *texturePtr, int eye);
+SetColorBufferFromUnity(void *texturePtr, std::uint8_t eye);
 
 UNITY_INTERFACE_EXPORT void UNITY_INTERFACE_API
 SetFarClipDistance(double distance);


### PR DESCRIPTION
Changes int to std::uint8_t, although this did not fix the bug/crash we are seeing in Unity (which occurs on some machines more often than others).
Caches nonzero viewport values and returns them to Unity when we hit a bug that causes the width and height of viewport to be 0 temporarily. 
This avoids a crash but does not fix the bug.