### PR TITLE
Don't access s_renderInfo from the Unity thread, instead read from s_…

### DIFF
--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -83,6 +83,7 @@ static osvr::renderkit::RenderManager *s_render = nullptr;
 static OSVR_ClientContext s_clientContext = nullptr;
 static std::vector<osvr::renderkit::RenderBuffer> s_renderBuffers;
 static std::vector<osvr::renderkit::RenderInfo> s_renderInfo;
+static std::vector<osvr::renderkit::RenderInfo> s_lastRenderInfo;
 static osvr::renderkit::GraphicsLibrary s_library;
 static void *s_leftEyeTexturePtr = nullptr;
 static void *s_rightEyeTexturePtr = nullptr;
@@ -321,6 +322,10 @@ void UNITY_INTERFACE_API UnityPluginUnload() {
 
 inline void UpdateRenderInfo() {
     s_renderInfo = s_render->GetRenderInfo(s_renderParams);
+	if (s_renderInfo.size() > 0)
+	{
+		s_lastRenderInfo = s_renderInfo;
+	}
 }
 
 #if 0
@@ -678,16 +683,16 @@ void UNITY_INTERFACE_API SetIPD(double ipdMeters) {
 
 osvr::renderkit::OSVR_ViewportDescription UNITY_INTERFACE_API
 GetViewport(int eye) {
-    return s_renderInfo[eye].viewport;
+	return s_lastRenderInfo[eye].viewport;
 }
 
 osvr::renderkit::OSVR_ProjectionMatrix UNITY_INTERFACE_API
 GetProjectionMatrix(int eye) {
-    return s_renderInfo[eye].projection;
+	return s_lastRenderInfo[eye].projection;
 }
 
 OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(int eye) {
-    return s_renderInfo[eye].pose;
+	return s_lastRenderInfo[eye].pose;
 }
 
 // --------------------------------------------------------------------------

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -324,13 +324,12 @@ void UNITY_INTERFACE_API UnityPluginUnload() {
 }
 
 inline void UpdateRenderInfo() {
-	m_mutex.lock();
-	s_renderInfo = s_render->GetRenderInfo(s_renderParams);
+	std::lock_guard<std::mutex> lock(m_mutex);
+    s_renderInfo = s_render->GetRenderInfo(s_renderParams);
 	if (s_renderInfo.size() > 0)
 	{
 		s_lastRenderInfo = s_renderInfo;
 	}
-	m_mutex.unlock();
 }
 
 #if 0
@@ -688,25 +687,19 @@ void UNITY_INTERFACE_API SetIPD(double ipdMeters) {
 
 osvr::renderkit::OSVR_ViewportDescription UNITY_INTERFACE_API
 GetViewport(int eye) {
-	m_mutex.lock();
-	osvr::renderkit::OSVR_ViewportDescription viewport = s_lastRenderInfo[eye].viewport;
-	m_mutex.unlock();
-	return viewport;
+	std::lock_guard<std::mutex> lock(m_mutex);
+	return s_lastRenderInfo[eye].viewport;
 }
 
 osvr::renderkit::OSVR_ProjectionMatrix UNITY_INTERFACE_API
 GetProjectionMatrix(int eye) {
-	m_mutex.lock();
-	osvr::renderkit::OSVR_ProjectionMatrix proj = s_lastRenderInfo[eye].projection;
-	m_mutex.unlock();
-	return proj;
+	std::lock_guard<std::mutex> lock(m_mutex);
+	return s_lastRenderInfo[eye].projection;
 }
 
 OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(int eye) {
-	m_mutex.lock();
-	OSVR_PoseState pose = s_lastRenderInfo[eye].pose;
-	m_mutex.unlock();
-	return pose;
+	std::lock_guard<std::mutex> lock(m_mutex);
+	return s_lastRenderInfo[eye].pose;
 }
 
 // --------------------------------------------------------------------------

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -324,12 +324,13 @@ void UNITY_INTERFACE_API UnityPluginUnload() {
 }
 
 inline void UpdateRenderInfo() {
-	std::lock_guard<std::mutex> lock(m_mutex);
-    s_renderInfo = s_render->GetRenderInfo(s_renderParams);
+	m_mutex.lock();
+	s_renderInfo = s_render->GetRenderInfo(s_renderParams);
 	if (s_renderInfo.size() > 0)
 	{
 		s_lastRenderInfo = s_renderInfo;
 	}
+	m_mutex.unlock();
 }
 
 #if 0
@@ -687,19 +688,25 @@ void UNITY_INTERFACE_API SetIPD(double ipdMeters) {
 
 osvr::renderkit::OSVR_ViewportDescription UNITY_INTERFACE_API
 GetViewport(int eye) {
-	std::lock_guard<std::mutex> lock(m_mutex);
-	return s_lastRenderInfo[eye].viewport;
+	m_mutex.lock();
+	osvr::renderkit::OSVR_ViewportDescription viewport = s_lastRenderInfo[eye].viewport;
+	m_mutex.unlock();
+	return viewport;
 }
 
 osvr::renderkit::OSVR_ProjectionMatrix UNITY_INTERFACE_API
 GetProjectionMatrix(int eye) {
-	std::lock_guard<std::mutex> lock(m_mutex);
-	return s_lastRenderInfo[eye].projection;
+	m_mutex.lock();
+	osvr::renderkit::OSVR_ProjectionMatrix proj = s_lastRenderInfo[eye].projection;
+	m_mutex.unlock();
+	return proj;
 }
 
 OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(int eye) {
-	std::lock_guard<std::mutex> lock(m_mutex);
-	return s_lastRenderInfo[eye].pose;
+	m_mutex.lock();
+	OSVR_PoseState pose = s_lastRenderInfo[eye].pose;
+	m_mutex.unlock();
+	return pose;
 }
 
 // --------------------------------------------------------------------------

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -821,21 +821,22 @@ inline void DoRender() {
     if (!s_deviceType) {
         return;
     }
-    const auto n = static_cast<int>(s_renderInfo.size());
+	std::lock_guard<std::mutex> lock(m_mutex);
+    const auto n = static_cast<int>(s_lastRenderInfo.size());
 
     switch (s_deviceType.getDeviceTypeEnum()) {
 #if SUPPORT_D3D11
     case OSVRSupportedRenderers::D3D11: {
 		// Render into each buffer using the specified information.
 		for (int i = 0; i < n; ++i) {
-			RenderViewD3D11(s_renderInfo[i],
+			RenderViewD3D11(s_lastRenderInfo[i],
 				s_renderBuffers[i].D3D11->colorBufferView, i);
 		}
 
         // Send the rendered results to the screen
         // Flip Y because Unity RenderTextures are upside-down on D3D11
         if (!s_render->PresentRenderBuffers(
-                s_renderBuffers, s_renderInfo,
+			s_renderBuffers, s_lastRenderInfo,
                 osvr::renderkit::RenderManager::RenderParams(),
                 std::vector<osvr::renderkit::OSVR_ViewportDescription>(),
                 true)) {

--- a/OsvrRenderingPlugin.cpp
+++ b/OsvrRenderingPlugin.cpp
@@ -120,6 +120,9 @@ enum RenderEvents {
     kOsvrEventID_ClearRoomToWorldTransform = 4
 };
 
+// Mutex provides thread safety when accessing s_lastRenderInfo from Unity
+std::mutex m_mutex;
+
 // --------------------------------------------------------------------------
 // Helper utilities
 
@@ -321,6 +324,7 @@ void UNITY_INTERFACE_API UnityPluginUnload() {
 }
 
 inline void UpdateRenderInfo() {
+	std::lock_guard<std::mutex> lock(m_mutex);
     s_renderInfo = s_render->GetRenderInfo(s_renderParams);
 	if (s_renderInfo.size() > 0)
 	{
@@ -683,15 +687,18 @@ void UNITY_INTERFACE_API SetIPD(double ipdMeters) {
 
 osvr::renderkit::OSVR_ViewportDescription UNITY_INTERFACE_API
 GetViewport(int eye) {
+	std::lock_guard<std::mutex> lock(m_mutex);
 	return s_lastRenderInfo[eye].viewport;
 }
 
 osvr::renderkit::OSVR_ProjectionMatrix UNITY_INTERFACE_API
 GetProjectionMatrix(int eye) {
+	std::lock_guard<std::mutex> lock(m_mutex);
 	return s_lastRenderInfo[eye].projection;
 }
 
 OSVR_Pose3 UNITY_INTERFACE_API GetEyePose(int eye) {
+	std::lock_guard<std::mutex> lock(m_mutex);
 	return s_lastRenderInfo[eye].pose;
 }
 


### PR DESCRIPTION
…lastRenderInfo. Appears to fix the random Unity crashes.